### PR TITLE
add method `resample`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,7 @@ subclasses must override the ``_registry`` and ``__call__`` methods.
       way.
     + ``MeasurementErrorSampler`` is a registry wrapper class and can be used
       in-place of any of its subclasses.
+    + Add method ``resample`` for ND array samples from ``PotentialSampler`` [#38]
 
 - ``GaussianMeasurementErrorSampler`` : uncorrelated Gaussian errors [#17]
 

--- a/discO/core/measurement.py
+++ b/discO/core/measurement.py
@@ -305,7 +305,8 @@ class MeasurementErrorSampler(PotentialBase):
 
             samples = []
             for samp, err in zip(c.T, c_err):
-                samples.append(self(samp, c_err=err, random=random, **kwargs))
+                result = self(samp, c_err=err, random=random, **kwargs)
+                samples.append(result)
 
             sample = concatenate(samples).reshape(c.shape)
 

--- a/discO/core/tests/test_measurement.py
+++ b/discO/core/tests/test_measurement.py
@@ -202,6 +202,8 @@ class Test_MeasurementErrorSampler(
             with pytest.raises(ValueError) as e:
                 self.obj(method="not None")
 
+            assert "Can't specify 'method'" in str(e.value)
+
             # ---------------
             # warns on return_specific_class
 
@@ -255,14 +257,50 @@ class Test_MeasurementErrorSampler(
         super().test___call__()
 
         # --------------------------
-        # with c_err
+        # with c_err and all bells and whistles
 
-        self.inst(self.c, self.c_err)
+        self.inst(self.c, self.c_err, random=0)
 
         # ---------------
         # without c_err, using from instantiation
 
         self.inst(self.c)
+
+    # /def
+
+    @pytest.mark.skip("TODO")
+    def test_resample(self):
+        """Test method ``resample``."""
+        # ---------------
+        # c_err = None
+
+        # ---------------
+        # len(c.shape) == 1
+
+        # ---------------
+        # 2D array, SkyCoord, nerriter = 1
+
+        # ---------------
+        # 2D array, SkyCoord, nerriter != niter
+
+        with pytest.raises(ValueError) as e:
+            self.inst.resample("TODO! inputs")
+
+        assert "c & c_err shape mismatch" in str(e.value)
+
+        # ---------------
+        # 2D array, SkyCoord, nerriter = niter
+
+        # ---------------
+        # 2D array, (Mapping, scalar, callable, %-unit)
+
+        # ---------------
+        # 2D array, other
+
+        with pytest.raises(NotImplementedError) as e:
+            self.inst.resample("TODO! inputs")
+
+        assert "not yet supported." in str(e.value)
 
     # /def
 


### PR DESCRIPTION
## Description

Add method ``resample`` to ``MeasurementErrorSampler`` (and all subclasses).

## PR Checklist

- [x] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [x] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [x] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [x] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [x] Ensure linear history by rebasing, when requested by the maintainer.
