### PR TITLE
rename specific_potential to potential

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -179,7 +179,7 @@ subclasses must override the ``_registry`` and ``__call__`` methods.
 
 - ``PotentialWrapper`` : base class for wrapping Potentials [#39]
 
-    + unified interface for the specific potential and specific force.
+    + unified interface for the potential and specific force.  [#39,#49]
     + all methods are both instance and static methods.
     + specific force returns a vector field.
     + ``frame`` and ``representation_type`` can be None or Ellipse or anything

--- a/discO/core/tests/test_residual.py
+++ b/discO/core/tests/test_residual.py
@@ -146,7 +146,7 @@ class Test_ResidualMethod(CommonBase_Test, obj=residual.ResidualMethod):
         assert inst._observable is self.observable
         assert inst._default_params == self.kwargs
         assert isinstance(inst._original_potential, PotentialWrapper)
-        assert inst._original_potential.potential is self.original_potential
+        assert inst._original_potential.wrapped is self.original_potential
         assert inst._original_potential.representation_type is expected
 
     # /def
@@ -334,7 +334,7 @@ class Test_GridResidual(Test_ResidualMethod, obj=residual.GridResidual):
         assert inst._observable is self.observable
         assert inst._default_params == self.kwargs
         assert isinstance(inst._original_potential, PotentialWrapper)
-        assert inst._original_potential.potential is self.original_potential
+        assert inst._original_potential.wrapped is self.original_potential
         assert inst._original_potential.representation_type is expected
 
     # /def

--- a/discO/core/tests/test_wrapper.py
+++ b/discO/core/tests/test_wrapper.py
@@ -182,10 +182,10 @@ class Test_PotentialWrapperMeta(ObjectTest, obj=wrapper.PotentialWrapperMeta):
 
     # /def
 
-    def test_specific_potential(self):
-        """Test method ``specific_potential``."""
+    def test_potential(self):
+        """Test method ``potential``."""
         with pytest.raises(NotImplementedError) as e:
-            self.subclass.specific_potential(self.potential, self.points)
+            self.subclass.potential(self.potential, self.points)
 
         assert "Please use the appropriate subpackage." in str(e.value)
 
@@ -369,10 +369,10 @@ class Test_PotentialWrapper(ObjectTest, obj=wrapper.PotentialWrapper):
     # /def
 
     @abc.abstractmethod
-    def test_specific_potential(self):
-        """Test method ``specific_potential``."""
+    def test_potential(self):
+        """Test method ``potential``."""
         with pytest.raises(NotImplementedError):
-            self.inst.specific_potential(self.points)
+            self.inst.potential(self.points)
 
     # /def
 

--- a/discO/core/wrapper.py
+++ b/discO/core/wrapper.py
@@ -159,7 +159,7 @@ class PotentialWrapperMeta(ABCMeta):
     # /def
 
     @abstractmethod
-    def specific_potential(
+    def potential(
         self,
         potential: T.Any,
         points: TH.PositionType,
@@ -446,7 +446,7 @@ class PotentialWrapper(metaclass=PotentialWrapperMeta):
     # -----------------------------------------------------
 
     @property
-    def potential(self) -> object:
+    def wrapped(self) -> object:
         """The wrapped potential."""
         return self.__wrapped__
 
@@ -514,7 +514,7 @@ class PotentialWrapper(metaclass=PotentialWrapperMeta):
         values : |Quantity|
 
         """
-        return self.specific_potential(
+        return self.potential(
             points, representation_type=representation_type, **kwargs
         )
 
@@ -540,7 +540,7 @@ class PotentialWrapper(metaclass=PotentialWrapperMeta):
     # -----------------------------------------------------
 
     @sharedmethod
-    def specific_potential(
+    def potential(
         self,
         points: TH.PositionType,
         *,
@@ -575,7 +575,7 @@ class PotentialWrapper(metaclass=PotentialWrapperMeta):
             else representation_type
         )
 
-        return self.__class__.specific_potential(
+        return self.__class__.potential(
             self.__wrapped__,  # potential
             points=points,
             frame=self.frame,

--- a/discO/plugin/agama/tests/test_wrapper.py
+++ b/discO/plugin/agama/tests/test_wrapper.py
@@ -64,19 +64,19 @@ class Test_AGAMAPotentialWrapperMeta(
 
     # /def
 
-    def test_specific_potential(self):
+    def test_potential(self):
         """Test method ``specific_force``."""
         # ---------------
         # when there isn't a frame
 
         with pytest.raises(TypeError) as e:
-            self.subclass.specific_potential(self.potential, self.points)
+            self.subclass.potential(self.potential, self.points)
 
         assert "the potential must have a frame." in str(e.value)
         # ---------------
         # basic
 
-        points, values = self.subclass.specific_potential(
+        points, values = self.subclass.potential(
             self.potential,
             self.points.data,
         )
@@ -101,7 +101,7 @@ class Test_AGAMAPotentialWrapperMeta(
             "galactocentric",
         ):
 
-            points, values = self.subclass.specific_potential(
+            points, values = self.subclass.potential(
                 self.potential,
                 self.points,
                 frame=frame,
@@ -116,7 +116,7 @@ class Test_AGAMAPotentialWrapperMeta(
         # ---------------
         # representation_type
 
-        points, values = self.subclass.specific_potential(
+        points, values = self.subclass.potential(
             self.potential,
             self.points,
             frame=self.points.frame.replicate_without_data(),
@@ -248,12 +248,12 @@ class Test_AGAMAPotentialWrapper(
 
     # /def
 
-    def test_specific_potential(self):
-        """Test method ``specific_potential``."""
+    def test_potential(self):
+        """Test method ``potential``."""
         # ---------------
         # basic
 
-        points, values = self.inst.specific_potential(self.points.data)
+        points, values = self.inst.potential(self.points.data)
 
         # check data types
         assert isinstance(points, self.inst.frame.__class__)
@@ -266,7 +266,7 @@ class Test_AGAMAPotentialWrapper(
         # ---------------
         # with a frame
 
-        points, values = self.inst.specific_potential(self.points)
+        points, values = self.inst.potential(self.points)
 
         # check data types
         assert isinstance(points, coord.SkyCoord)
@@ -283,7 +283,7 @@ class Test_AGAMAPotentialWrapper(
 
         with pytest.raises(TypeError) as e:
 
-            points, values = self.inst.specific_potential(
+            points, values = self.inst.potential(
                 self.points,
                 frame=coord.Galactocentric(),
             )
@@ -293,7 +293,7 @@ class Test_AGAMAPotentialWrapper(
         # ---------------
         # representation_type
 
-        points, values = self.inst.specific_potential(
+        points, values = self.inst.potential(
             self.points,
             representation_type=coord.CartesianRepresentation,
         )

--- a/discO/plugin/agama/wrapper.py
+++ b/discO/plugin/agama/wrapper.py
@@ -59,7 +59,7 @@ class AGAMAPotentialMeta(PotentialWrapperMeta):
 
     # -----------------------------------------------------
 
-    def specific_potential(
+    def potential(
         self,
         potential: PotentialType,
         points: TH.PositionType,

--- a/discO/plugin/galpy/tests/test_residual.py
+++ b/discO/plugin/galpy/tests/test_residual.py
@@ -83,7 +83,7 @@ class Test_GridResidual_Galpy(GridResidual_Test, obj=residual.GridResidual):
         assert inst._observable is self.observable
         assert inst._default_params == self.kwargs
         assert isinstance(inst._original_potential, GalpyPotentialWrapper)
-        assert inst._original_potential.potential is self.original_potential
+        assert inst._original_potential.wrapped is self.original_potential
         assert inst._original_potential.representation_type is expected
 
     # /def

--- a/discO/plugin/galpy/tests/test_wrapper.py
+++ b/discO/plugin/galpy/tests/test_wrapper.py
@@ -68,20 +68,20 @@ class Test_GalpyPotentialWrapperMeta(
 
     # /def
 
-    def test_specific_potential(self):
+    def test_potential(self):
         """Test method ``specific_force``."""
         # ---------------
         # when there isn't a frame
 
         with pytest.raises(TypeError) as e:
-            self.subclass.specific_potential(self.potential, self.points)
+            self.subclass.potential(self.potential, self.points)
 
         assert "the potential must have a frame." in str(e.value)
 
         # ---------------
         # basic
 
-        points, values = self.subclass.specific_potential(
+        points, values = self.subclass.potential(
             self.potential,
             self.points.data,
         )
@@ -106,7 +106,7 @@ class Test_GalpyPotentialWrapperMeta(
             "galactocentric",
         ):
 
-            points, values = self.subclass.specific_potential(
+            points, values = self.subclass.potential(
                 self.potential,
                 self.points,
                 frame=frame,
@@ -121,7 +121,7 @@ class Test_GalpyPotentialWrapperMeta(
         # ---------------
         # representation_type
 
-        points, values = self.subclass.specific_potential(
+        points, values = self.subclass.potential(
             self.potential,
             self.points,
             frame=self.points.frame.replicate_without_data(),
@@ -278,12 +278,12 @@ class Test_GalpyPotentialWrapper(
 
     # /def
 
-    def test_specific_potential(self):
+    def test_potential(self):
         """Test method ``specific_force``."""
         # ---------------
         # basic
 
-        points, values = self.inst.specific_potential(self.points.data)
+        points, values = self.inst.potential(self.points.data)
 
         # check data types
         assert isinstance(points, self.inst.frame.__class__)
@@ -296,7 +296,7 @@ class Test_GalpyPotentialWrapper(
         # ---------------
         # with a frame
 
-        points, values = self.inst.specific_potential(self.points)
+        points, values = self.inst.potential(self.points)
 
         # check data types
         assert isinstance(points, coord.SkyCoord)
@@ -313,7 +313,7 @@ class Test_GalpyPotentialWrapper(
 
         with pytest.raises(TypeError) as e:
 
-            points, values = self.inst.specific_potential(
+            points, values = self.inst.potential(
                 self.points,
                 frame=coord.Galactocentric(),
             )
@@ -323,7 +323,7 @@ class Test_GalpyPotentialWrapper(
         # ---------------
         # representation_type
 
-        points, values = self.inst.specific_potential(
+        points, values = self.inst.potential(
             self.points,
             representation_type=coord.CartesianRepresentation,
         )

--- a/discO/plugin/galpy/wrapper.py
+++ b/discO/plugin/galpy/wrapper.py
@@ -58,7 +58,7 @@ class GalpyPotentialMeta(PotentialWrapperMeta):
 
     # -----------------------------------------------------
 
-    def specific_potential(
+    def potential(
         self,
         potential: PotentialType,
         points: TH.PositionType,


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

## Description

Lol. specific potential is the potential. I meant specific potential energy before.


## PR Checklist

- [x] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [x] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [x] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [x] Add tests, if applicable, to ensure code coverage never decreases.
- [x] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [x] Ensure linear history by rebasing, when requested by the maintainer.
